### PR TITLE
Fix network error message handling

### DIFF
--- a/Poem of the Day/ContentView.swift
+++ b/Poem of the Day/ContentView.swift
@@ -429,7 +429,11 @@ class PoemViewModel: ObservableObject {
             .catch { [weak self] error -> AnyPublisher<Poem, Never> in
                 DispatchQueue.main.async {
                     self?.showAlert = true
-                    self?.alertMessage = "The poem could not be found (404 error). Please try again later."
+                    if let urlError = error as? URLError, urlError.code == .fileDoesNotExist {
+                        self?.alertMessage = "The poem could not be found (404 error). Please try again later."
+                    } else {
+                        self?.alertMessage = "Failed to load the poem of the day. Please try again later."
+                    }
                 }
                 return Just(Poem(id: UUID(), title: "Default Poem", lines: ["This is a default poem content."])).eraseToAnyPublisher()
             }


### PR DESCRIPTION
## Summary
- fix incorrect 404-only error message during poem fetch

## Testing
- `swift test --parallel` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6848bd8f15d8832ebdb9cab95bc202a0