### PR TITLE
Improve error messaging for 404

### DIFF
--- a/Poem of the Day/ContentView.swift
+++ b/Poem of the Day/ContentView.swift
@@ -429,9 +429,16 @@ class PoemViewModel: ObservableObject {
             .catch { [weak self] error -> AnyPublisher<Poem, Never> in
                 DispatchQueue.main.async {
                     self?.showAlert = true
-                    self?.alertMessage = "The poem could not be found (404 error). Please try again later."
+                    if let urlError = error as? URLError,
+                       urlError.code == .fileDoesNotExist {
+                        self?.alertMessage = "The poem could not be found (404 error). Please try again later."
+                    } else {
+                        self?.alertMessage = "Failed to fetch poem. Please try again later."
+                    }
                 }
-                return Just(Poem(id: UUID(), title: "Default Poem", lines: ["This is a default poem content."])).eraseToAnyPublisher()
+                return Just(
+                    Poem(id: UUID(), title: "Default Poem", lines: ["This is a default poem content."])
+                ).eraseToAnyPublisher()
             }
             
             .sink(receiveCompletion: { [weak self] completion in


### PR DESCRIPTION
## Summary
- update error handling in `fetchPoemOfTheDay`
  - show specific message for URLError `.fileDoesNotExist`
  - show generic message for other failures

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6848be7ab424832ea17a442eb5d52da7