### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 2. Open the project in Xcode.
    ```bash
    cd poem-of-the-day-widget
-   open PoemOfTheDay.xcodeproj
+   open 'Poem of the Day.xcodeproj'
    ```
 3. Run the app using the iOS Simulator or a physical device.
 


### PR DESCRIPTION
## Summary
- fix the `open` command in README

## Testing
- `pandoc README.md -o /tmp/README.html`
- `markdownlint README.md` *(fails: line-length, blanks-around-fences)*

------
https://chatgpt.com/codex/tasks/task_e_6848be7a9610832e82e7c4dfb9d35996