### PR TITLE
Fix CI scheme

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,7 +25,7 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
 
       - name: Build and test
-        run: xcodebuild -scheme "MyApp" -destination 'platform=iOS Simulator,name=iPhone 12' test
+        run: xcodebuild -project "Poem of the Day.xcodeproj" -scheme "Poem of the Day" -destination 'platform=iOS Simulator,name=iPhone 12' build test
         continue-on-error: false # Ensure this step must pass
 
       # Runs a set of commands using the runners shell


### PR DESCRIPTION
## Summary
- use correct scheme name in CI

## Testing
- `xcodebuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c0863f74832e90673f5e73bc1a6a