### PR TITLE
Update Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,48 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "Poem-of-the-Day",
+    platforms: [
+        .iOS(.v17)
+    ],
+    products: [
+        .library(name: "Poem_of_the_Day", targets: ["Poem_of_the_Day"]),
+        .library(name: "Poem_of_the_Day_Widget", targets: ["Poem_of_the_Day_Widget"])
+    ],
+    targets: [
+        .target(
+            name: "Poem_of_the_Day",
+            path: "Poem of the Day",
+            exclude: ["Poem of the Day.entitlements"],
+            resources: [
+                .process("Assets.xcassets"),
+                .process("Preview Content")
+            ]
+        ),
+        .target(
+            name: "Poem_of_the_Day_Widget",
+            dependencies: ["Poem_of_the_Day"],
+            path: "Poem of the Day Widget",
+            exclude: ["Info.plist"],
+            resources: [
+                .process("Assets.xcassets")
+            ]
+        ),
+        .testTarget(
+            name: "Poem_of_the_DayTests",
+            dependencies: ["Poem_of_the_Day"],
+            path: "Poem of the DayTests"
+        )
+    ]
+)
+
+#if canImport(Darwin)
+package.targets.append(
+    .testTarget(
+        name: "Poem_of_the_DayUITests",
+        dependencies: [],
+        path: "Poem of the DayUITests"
+    )
+)
+#endif


### PR DESCRIPTION
## Summary
- exclude entitlements and plist files from SPM targets
- add UI tests only when building on Apple platforms

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6848c103d3e8832e8f29eaa0bbd885db