### PR TITLE
Add unit test and update workflow

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,5 +25,5 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
 
       - name: Build and test
-        run: xcodebuild -scheme "Poem of the Day" -destination 'platform=iOS Simulator,name=iPhone 15' test
+        run: xcodebuild -scheme "Poem of the Day" -destination 'platform=iOS Simulator,name=iPhone 16' test
         continue-on-error: false # Ensure this step must pass

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,11 +25,5 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
 
       - name: Build and test
-        run: xcodebuild -scheme "Poem of the Day" -destination 'platform=iOS Simulator,name=iPhone 16' test
+        run: xcodebuild -scheme "Poem of the Day" -destination 'platform=iOS Simulator,name=iPhone 15' test
         continue-on-error: false # Ensure this step must pass
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
-        run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.

--- a/Poem of the DayTests/PoemViewModelTests.swift
+++ b/Poem of the DayTests/PoemViewModelTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import Combine
+@testable import Poem_of_the_Day
+
+class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: "No handler", code: 0))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+final class PoemViewModelTests: XCTestCase {
+    var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+        URLProtocol.registerClass(MockURLProtocol.self)
+    }
+
+    override func tearDown() {
+        URLProtocol.unregisterClass(MockURLProtocol.self)
+        MockURLProtocol.requestHandler = nil
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testFetchPoemOfTheDayDecodesData() {
+        let expectation = expectation(description: "Poem fetched")
+
+        let json = """
+        [{
+            "title": "Sample Title",
+            "lines": ["Line one", "Line two"],
+            "author": "Tester"
+        }]
+        """
+        let data = json.data(using: .utf8)!
+        MockURLProtocol.requestHandler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, data)
+        }
+
+        let viewModel = PoemViewModel()
+        viewModel.$poemOfTheDay
+            .dropFirst()
+            .sink { poem in
+                if let poem = poem {
+                    XCTAssertEqual(poem.title, "Sample Title")
+                    XCTAssertEqual(poem.content, "Line one\nLine two")
+                    XCTAssertEqual(poem.author, "Tester")
+                    expectation.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        viewModel.fetchPoemOfTheDay(force: true)
+
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/Poem of the DayTests/Poem_of_the_DayTests.swift
+++ b/Poem of the DayTests/Poem_of_the_DayTests.swift
@@ -1,17 +1,8 @@
-//
-//  Poem_of_the_DayTests.swift
-//  Poem of the DayTests
-//
-//  Created by Stephen Reitz on 11/14/24.
-//
-
-import Testing
+import XCTest
 @testable import Poem_of_the_Day
 
-struct Poem_of_the_DayTests {
-
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+final class Poem_of_the_DayTests: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
     }
-
 }


### PR DESCRIPTION
## Summary
- create `PoemViewModelTests` using XCTest with mocked URLSession
- convert placeholder test to XCTest
- run tests on GitHub Actions with `xcodebuild`

## Testing
- `xcodebuild -scheme "Poem of the Day" -destination 'platform=iOS Simulator,name=iPhone 15' test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848c838a240832e8e7cc24a0239c0ea