### PR TITLE
Improve App Store visibility: review prompts, quick actions, ASO metadata

### DIFF
--- a/AppStoreDescription.md
+++ b/AppStoreDescription.md
@@ -1,95 +1,73 @@
-# App Store Description
+# App Store Metadata
 
-## Poem of the Day - AI Poetry with Dynamic Colors
+## App Name (max 30 characters)
 
-**Experience poetry that adapts to the world around you**
+Poem of the Day: AI Poetry
 
-Transform your daily routine with intelligent poetry that responds to the world's mood. Poem of the Day combines AI-powered verse generation with dynamic background colors that shift based on real-time sentiment analysis, creating a uniquely immersive literary experience.
+## Subtitle (max 30 characters)
 
-### ✨ What Makes It Special
+Daily Verse & AI Vibe Poems
 
-**🎨 Revolutionary Color Experience**
-Watch your app transform throughout the day as background colors automatically adapt to global emotions. From hopeful golden sunrises during positive news cycles to contemplative blues during reflective moments, every interaction becomes visually meaningful.
+## Keywords (max 100 characters, no spaces after commas)
 
-**🤖 AI-Powered Poetry**
-Generate personalized poems that match today's emotional landscape. Our advanced AI analyzes current events to create verse that resonates with the collective human experience, making every poem timely and relevant.
+poetry,poem,daily,verse,AI,haiku,lyric,literature,favorites,widget,mindfulness,rhyme,classics,nature
 
-**📚 Beautiful Daily Poetry**
-Discover hand-curated classical and contemporary poems delivered fresh each day. Our elegant typography and dynamic backgrounds create the perfect reading environment for literary appreciation.
+## Description
 
-### 🌟 Key Features
+Start every morning with the perfect poem.
 
-- **10 Dynamic Mood Palettes**: Intelligent color schemes that respond to daily sentiment analysis
-- **AI Poem Generation**: Create custom poetry based on current global vibes or personal prompts
-- **Daily Curated Content**: Hand-selected poems refreshed every day
-- **Smart Favorites System**: Save and organize your most beloved verses
-- **Home Screen Widgets**: Beautiful poems displayed directly on your home screen
-- **Full Accessibility**: VoiceOver, Dynamic Type, and inclusive design support
-- **Seamless Sharing**: Share meaningful poetry with friends and social media
+Poem of the Day delivers a hand-curated verse each day, then uses Apple Intelligence to analyze the world's mood and wrap it in a matching color palette — so your app literally feels different on a hopeful day versus a reflective one.
 
-### 🎭 Emotional Intelligence
+**What's inside:**
 
-Our revolutionary Vibe Analysis Engine processes real-time news to determine the world's emotional state, then automatically adjusts:
+• **Daily curated poem** — a fresh classical or contemporary verse every morning
+• **10 Vibe color palettes** — background gradients that shift with the news sentiment (Hopeful, Energetic, Peaceful, Melancholic, and more)
+• **AI Vibe Poem** — one tap generates a poem tuned to today's global mood via Apple Intelligence
+• **Custom AI Poetry** — write any prompt and get an original poem in seconds
+• **Home screen widget** — your daily poem right on your lock screen or home screen, no app opens needed
+• **Favorites** — save the lines that move you and revisit them anytime
+• **Poem history** — scroll back through every verse you've seen
+• **Seamless sharing** — send a poem to anyone with one tap
+• **Full accessibility** — VoiceOver, Dynamic Type, and high-contrast support built in
 
-- **Background Colors**: 10 unique palettes from energetic oranges to peaceful blues
-- **Poem Selection**: AI-generated content that matches the collective mood
-- **Visual Intensity**: Color vibrancy scales with emotional confidence
-- **Smooth Transitions**: Elegant animations between emotional states
+**How the Vibe Engine works**
 
-### 💎 Premium Experience
+Poem of the Day reads real-time news headlines, scores the collective emotional tone, and maps it to one of 10 moods. The app's background gradient changes color and intensity to match — a gentle visual reminder of how the world feels right now. Apple Intelligence then crafts a poem that speaks to that feeling.
 
-- **Native SwiftUI**: Built specifically for iOS with smooth, responsive interactions
-- **Privacy-First**: Optional analytics with complete transparency
-- **Offline Access**: Read favorite poems anywhere, anytime
-- **Performance Optimized**: Lightning-fast loading and minimal battery usage
-- **Regular Updates**: Fresh content and features added continuously
+**Privacy first**
 
-### 🎯 Perfect For
+All AI processing runs on-device using Apple Intelligence. News analysis is read-only. Optional, fully transparent analytics that you can disable at any time.
 
-- **Poetry Enthusiasts**: Discover new verses and revisit classics with enhanced visual appeal
-- **Mindfulness Practitioners**: Daily reflection enhanced by mood-responsive environments
-- **Creative Writers**: Find inspiration through AI-generated examples and prompts
-- **Students & Educators**: Explore literature with innovative interactive features
-- **Anyone Seeking Beauty**: Transform routine moments into meaningful experiences
-
-### 🏆 Awards & Recognition
-
-- Featured in "Best Apps for Literature Lovers"
-- Recognized for Innovative AI Implementation
-- Accessibility Excellence Award Winner
-- 5-Star User Rating with 10,000+ Reviews
-
-### 📱 Requirements
+**Requirements**
 
 - iOS 18.0 or later
-- Compatible with iPhone, iPad, and iPod touch
-- Optimized for all screen sizes and orientations
-- Supports Dark Mode and Dynamic Type
+- iPhone, iPad, or iPod touch
+- Apple Intelligence required for AI poem generation (device-dependent)
+- Supports Dark Mode, Dynamic Type, and all screen sizes
 
-### 🎈 What Users Say
-
-*"The background colors make poetry feel alive! I check the app every morning to see what mood the world is in."* - Sarah M.
-
-*"Finally, an AI that creates meaningful poetry instead of random words. The vibe-based generation is brilliant."* - Michael K.
-
-*"Beautiful typography, smooth animations, and thoughtful design. This is how poetry apps should be made."* - Jennifer L.
-
----
-
-**Download now and discover how poetry comes alive when it responds to the world around you.**
-
-## Short Description (for App Store subtitle)
-
-AI-powered daily poetry with dynamic backgrounds that change based on world sentiment analysis.
-
-## Keywords
-
-poetry, poems, AI, artificial intelligence, daily, literature, mood, sentiment, background, colors, dynamic, adaptive, news, analysis, favorites, widgets, mindfulness, reflection, creative writing, inspiration, beautiful, elegant
+Download now and make poetry part of your day.
 
 ## App Category
 
-Books & Reference / Entertainment
+Books & Reference
+
+## Secondary Category
+
+Entertainment
 
 ## Content Rating
 
-4+ (Suitable for all ages) 
+4+ (Suitable for all ages)
+
+## App Store Screenshots — Caption Guide
+
+### iPhone 6.7" (required)
+1. **Home — Daily Poem** "A new poem, every morning"
+2. **Vibe Analysis** "The world's mood, in color"
+3. **AI Vibe Poem** "Poetry powered by Apple Intelligence"
+4. **Custom AI Poem** "Any prompt. Instant verse."
+5. **Favorites** "Save the lines that move you"
+6. **Widget** "Your poem on the home screen"
+
+### iPad (recommended)
+Same sequence, tablet layout.

--- a/Poem of the Day/Core/StorageKeys.swift
+++ b/Poem of the Day/Core/StorageKeys.swift
@@ -42,7 +42,15 @@ enum StorageKeys {
     static let widgetTelemetryEvents = "widget_telemetry_events"
     
     // MARK: - Notifications
-    
+
     static let notificationSettings = "notificationSettings"
+
+    // MARK: - Review Requests
+
+    static let reviewAppLaunchCount = "review_appLaunchCount"
+    static let reviewFavoritesAddedCount = "review_favoritesAddedCount"
+    static let reviewAIPoemsGeneratedCount = "review_aiPoemsGeneratedCount"
+    static let reviewLastRequestDate = "review_lastRequestDate"
+    static let reviewTotalRequestCount = "review_totalRequestCount"
 }
 

--- a/Poem of the Day/Poem_of_the_DayApp.swift
+++ b/Poem of the Day/Poem_of_the_DayApp.swift
@@ -6,15 +6,73 @@
 //
 
 import SwiftUI
+import UIKit
+
+// MARK: - Quick Action Types
+
+enum QuickActionType: String {
+    case newPoem    = "com.stevereitz.poemoftheday.newpoem"
+    case favorites  = "com.stevereitz.poemoftheday.favorites"
+    case vibePoem   = "com.stevereitz.poemoftheday.vibepoem"
+}
+
+// MARK: - App Delegate
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        NotificationCenter.default.post(
+            name: .quickActionTriggered,
+            object: shortcutItem.type
+        )
+        completionHandler(true)
+    }
+}
+
+extension Notification.Name {
+    static let quickActionTriggered = Notification.Name("QuickActionTriggered")
+}
+
+// MARK: - App Entry Point
 
 @main
 struct Poem_of_the_DayApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var dependencies = DependencyContainer.shared
-    
+
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environmentObject(dependencies)
+                .onAppear {
+                    registerQuickActions()
+                }
         }
+    }
+
+    private func registerQuickActions() {
+        UIApplication.shared.shortcutItems = [
+            UIApplicationShortcutItem(
+                type: QuickActionType.newPoem.rawValue,
+                localizedTitle: "New Poem",
+                localizedSubtitle: nil,
+                icon: UIApplicationShortcutIcon(systemImageName: "arrow.clockwise")
+            ),
+            UIApplicationShortcutItem(
+                type: QuickActionType.favorites.rawValue,
+                localizedTitle: "Favorites",
+                localizedSubtitle: nil,
+                icon: UIApplicationShortcutIcon(systemImageName: "heart.fill")
+            ),
+            UIApplicationShortcutItem(
+                type: QuickActionType.vibePoem.rawValue,
+                localizedTitle: "Vibe Poem",
+                localizedSubtitle: "AI-powered verse",
+                icon: UIApplicationShortcutIcon(systemImageName: "brain.head.profile")
+            ),
+        ]
     }
 }

--- a/Poem of the Day/Services/ReviewRequestService.swift
+++ b/Poem of the Day/Services/ReviewRequestService.swift
@@ -1,0 +1,80 @@
+//
+//  ReviewRequestService.swift
+//  Poem of the Day
+//
+
+import StoreKit
+import UIKit
+
+/// Tracks positive engagement events and requests App Store reviews at appropriate moments.
+/// Apple allows at most 3 review requests per 365-day period; this service adds its own
+/// 60-day cooldown so we never burn the quota on low-engagement sessions.
+@MainActor
+final class ReviewRequestService {
+    static let shared = ReviewRequestService()
+
+    private let defaults = UserDefaults.standard
+
+    private enum Keys {
+        static let appLaunchCount = "review_appLaunchCount"
+        static let favoritesAddedCount = "review_favoritesAddedCount"
+        static let aiPoemsGeneratedCount = "review_aiPoemsGeneratedCount"
+        static let lastRequestDate = "review_lastRequestDate"
+        static let totalRequestCount = "review_totalRequestCount"
+    }
+
+    private init() {}
+
+    func recordAppLaunch() {
+        let count = increment(Keys.appLaunchCount)
+        // Third launch: user is returning — a good moment to ask
+        if count == 3 {
+            requestReviewIfAppropriate()
+        }
+    }
+
+    func recordFavoriteAdded() {
+        let count = increment(Keys.favoritesAddedCount)
+        // Second favorite means the user is building a collection
+        if count == 2 {
+            requestReviewIfAppropriate()
+        }
+    }
+
+    func recordAIPoemGenerated() {
+        let count = increment(Keys.aiPoemsGeneratedCount)
+        // First AI poem: high-intent action worth asking about
+        if count == 1 {
+            requestReviewIfAppropriate()
+        }
+    }
+
+    // MARK: - Private
+
+    @discardableResult
+    private func increment(_ key: String) -> Int {
+        let next = defaults.integer(forKey: key) + 1
+        defaults.set(next, forKey: key)
+        return next
+    }
+
+    private func requestReviewIfAppropriate() {
+        // Stay well under Apple's 3-per-year cap
+        guard defaults.integer(forKey: Keys.totalRequestCount) < 3 else { return }
+
+        // Respect a 60-day cooldown between requests
+        if let last = defaults.object(forKey: Keys.lastRequestDate) as? Date {
+            let days = Calendar.current.dateComponents([.day], from: last, to: Date()).day ?? 0
+            guard days >= 60 else { return }
+        }
+
+        guard let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+        else { return }
+
+        AppStore.requestReview(in: scene)
+
+        increment(Keys.totalRequestCount)
+        defaults.set(Date(), forKey: Keys.lastRequestDate)
+    }
+}

--- a/Poem of the Day/ViewModels/PoemViewModel.swift
+++ b/Poem of the Day/ViewModels/PoemViewModel.swift
@@ -34,8 +34,10 @@ final class PoemViewModel: ObservableObject {
     }
     
     func loadInitialData() async {
+        ReviewRequestService.shared.recordAppLaunch()
+
         let isUITesting = AppConfiguration.Testing.isUITesting
-        
+
         if isUITesting {
             isLoading = true
             isAIGenerationAvailable = AppConfiguration.Testing.isAIAvailable
@@ -147,33 +149,36 @@ final class PoemViewModel: ObservableObject {
         } else {
             AppLogger.shared.info("Poem is NOT favorite. Adding.", category: .ui)
             await repository.addToFavorites(poem)
+            ReviewRequestService.shared.recordFavoriteAdded()
         }
-        
+
         await loadFavorites()
     }
     
     
     func generateVibeBasedPoem() async {
         isLoading = true
-        
+
         do {
             poemOfTheDay = try await repository.generateVibeBasedPoem()
+            ReviewRequestService.shared.recordAIPoemGenerated()
         } catch {
             await handleError(error)
         }
-        
+
         isLoading = false
     }
-    
+
     func generateCustomPoem(prompt: String) async {
         isLoading = true
-        
+
         do {
             poemOfTheDay = try await repository.generateCustomPoem(prompt: prompt)
+            ReviewRequestService.shared.recordAIPoemGenerated()
         } catch {
             await handleError(error)
         }
-        
+
         isLoading = false
     }
     

--- a/Poem of the Day/Views/Screens/ContentView.swift
+++ b/Poem of the Day/Views/Screens/ContentView.swift
@@ -193,6 +193,18 @@ struct ContentView: View {
         .task {
             await viewModel.loadInitialData()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .quickActionTriggered)) { note in
+            guard let type = note.object as? String,
+                  let action = QuickActionType(rawValue: type) else { return }
+            switch action {
+            case .newPoem:
+                Task { await viewModel.refreshPoem(showLoading: true) }
+            case .favorites:
+                showFavorites = true
+            case .vibePoem:
+                viewModel.showVibeGeneration = true
+            }
+        }
     }
     
     private func provideFeedback(success: Bool) {


### PR DESCRIPTION
- Add ReviewRequestService (StoreKit) that requests a review after the
  3rd app launch, 2nd favorited poem, or first AI poem generation.
  Built-in 60-day cooldown prevents burning Apple's 3-per-year quota.
- Trigger review prompts from PoemViewModel at each engagement milestone.
- Register dynamic home screen quick actions (New Poem, Favorites, Vibe
  Poem) via UIApplicationShortcutItem so power users can jump straight
  to a feature from a long-press on the app icon.
- Handle quick action notifications in ContentView via NotificationCenter.
- Overhaul AppStoreDescription.md: title ≤30 chars, subtitle ≤30 chars,
  keyword field at exactly 100 chars, plain accurate description
  (removed fabricated awards/review-count claims), screenshot captions.

https://claude.ai/code/session_01WZsaHrG3qeo6uDsnqPDkrZ