### PR TITLE
Fix CI simulator version to match available runtime

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,5 +29,5 @@ test --test_timeout=900
 test --test_env=OS_ACTIVITY_MODE=disable
 
 # CI Configuration
-test:ci --ios_simulator_version=18.6
+test:ci --ios_simulator_version=26.1
 test:ci --test_output=all


### PR DESCRIPTION
The CI runner provides iOS 26.1 and 26.2 simulators but the ci config was overriding the simulator version to 18.6, causing all test runs to fail immediately before any test code ran.

https://claude.ai/code/session_01WZsaHrG3qeo6uDsnqPDkrZ